### PR TITLE
Adding Hacktech 2025

### DIFF
--- a/Hackathons_2025/Hacktech-2025.md
+++ b/Hackathons_2025/Hacktech-2025.md
@@ -1,0 +1,56 @@
+# Hacktech
+Hacktech is an intercollegiate hackathon hosted by the California Institute of Technology. This iteration was hosted from 4/25 to 4/27 in 2025 at Pasadena, CA, USA. 
+
+## Event Summary
+
+Hacktech was the first major west-coast hackathon, and this is the 11-th iteration! This was also the first fully in-person hackathon hosted by Caltech since the COVID-19 pandemic. Our hackathon featured three tracks: 
+Healthcare, Sustainability, and Finance/Data Analytics. We hosted the Github Copilot workshop, held by our friends over at MLH. We also had two fantastic keynote speakers: 
+- Professor Anima Anandkumar. Bren Professor of Computing at Caltech, former Senior Director of ML Research at NVIDIA, and TIME 100 Impact Award recipient. 
+- Kip Thorne. Former Feynman Professor of Theoretical Physics at Caltech (until 2009), Nobel Laureatte, and consultant for the famous movies Oppenheimer and Interstellar. 
+Github played a major role in helping our participants collaborate in a shared codespace, and we requested that the participants share their repositories in the submission tool so that we could take a look at their work as well!
+
+## Event Metrics 
+Thie event received 2400+ applicants, from which we selected ~400 to attend our event in person. The hackathon had ~$60k worth of prizes for our participants! 
+
+| Attendees |First Time Hackers| Projects|
+|---------------:|--------------:|------------:|
+|256|~70|[54 total projects](https://hacktech2025.devpost.com/project-gallery)| 
+
+## Tech Impact / Diversity 
+
+### Tell us about your hacker demographics
+Our event was targetted towards university students of all levels of experience and background. We accepted university students from all over the country. 
+
+ - Who was the target audience for your event? <br> 
+ - What does the diversity breakdown look like? (Include the percentage of hackers who identify as female, non-binary or other) <br>
+
+### What race & ethnicities did your hackers identify as?
+| Native American / <br> Alaskan Native | Black / <br> African American | Hispanic / <br> Latinx | Asian | White |
+|---------------:|--------------:|------------:|---------:|--------:|
+|{# of hackers}|{# of hackers}|{# of hackers}|{# of hackers}|{# of hackers}|
+
+
+### Where were your hackers from?
+Our hackers were all US university students. 
+
+## Impact of GitHub Grant
+We used grant funds to help provide prizes to the hackers - thanks to Github, we were able to partially fund the prize for the winners of the Healthcare track. 
+With these funds, hackers were able to go home with prizes they're happy with. 
+
+## Top Projects
+One of the coolest projects at our event was the winner of our Best Use of AI award, Renaissance Research. 
+
+https://devpost.com/software/renaissance-research?_gl=1*1hguy6j*_gcl_au*MTYxMzIxMjE1OS4xNzQ1NzMxMzc1*_ga*NjAyODY5OTY2LjE3NDU3MzEzNzU.*_ga_0YHJK3Y10M*MTc0NTg3NzI5OS4yLjEuMTc0NTg3Nzk3Ny4wLjAuMA. 
+
+Github was used to house this project's code! This project had an amazing emphasis on scalability, a good technical implementation, and an amazing motivation. 
+The impact of finding even one useful research paper during a large project is immeasurable. 
+
+## Event Photos
+
+| <img src="https://drive.usercontent.google.com/download?id=1Al9IJniEYR9JQFI721N6sxqSK28j19JL&authuser=0" width="500" height="auto"> |
+|:--:|
+| <b> Hacktech Closing Ceremony! </b>|
+
+## What’s Next?
+Overall, we were extremely happy with the attendance, atmosphere, and energy of our event. We got to see some amazing projects!
+We will host the next iteration of Hacktech sometime in Spring 2026. Please follow at https://www.instagram.com/hacktechbycaltech/!

--- a/Hackathons_2025/Hacktech-2025.md
+++ b/Hackathons_2025/Hacktech-2025.md
@@ -6,7 +6,8 @@ Hacktech is an intercollegiate hackathon hosted by the California Institute of T
 Hacktech was the first major west-coast hackathon, and this is the 11-th iteration! This was also the first fully in-person hackathon hosted by Caltech since the COVID-19 pandemic. Our hackathon featured three tracks: 
 Healthcare, Sustainability, and Finance/Data Analytics. We hosted the Github Copilot workshop, held by our friends over at MLH. We also had two fantastic keynote speakers: 
 - Professor Anima Anandkumar. Bren Professor of Computing at Caltech, former Senior Director of ML Research at NVIDIA, and TIME 100 Impact Award recipient. 
-- Kip Thorne. Former Feynman Professor of Theoretical Physics at Caltech (until 2009), Nobel Laureatte, and consultant for the famous movies Oppenheimer and Interstellar. 
+- Kip Thorne. Former Feynman Professor of Theoretical Physics at Caltech (until 2009), Nobel Laureatte, and consultant for the famous movies Oppenheimer and Interstellar.
+
 Github played a major role in helping our participants collaborate in a shared codespace, and we requested that the participants share their repositories in the submission tool so that we could take a look at their work as well!
 
 ## Event Metrics 
@@ -21,14 +22,10 @@ Thie event received 2400+ applicants, from which we selected ~400 to attend our 
 ### Tell us about your hacker demographics
 Our event was targetted towards university students of all levels of experience and background. We accepted university students from all over the country. 
 
- - Who was the target audience for your event? <br> 
- - What does the diversity breakdown look like? (Include the percentage of hackers who identify as female, non-binary or other) <br>
+In total, it appears that 62.8% of our participants identify as male, 33.2% of our participants identify as female, 0.78% of our participants identified as non-binary, and the remaining 3.2% "Prefer not to say". 
 
 ### What race & ethnicities did your hackers identify as?
-| Native American / <br> Alaskan Native | Black / <br> African American | Hispanic / <br> Latinx | Asian | White |
-|---------------:|--------------:|------------:|---------:|--------:|
-|{# of hackers}|{# of hackers}|{# of hackers}|{# of hackers}|{# of hackers}|
-
+Unfortunately, we did not collect the this data from our participants. 
 
 ### Where were your hackers from?
 Our hackers were all US university students. 


### PR DESCRIPTION
This PR is to update the post-event report for Hacktech 2025, the 11-th iteration of Caltech's flagship hackathon. 